### PR TITLE
Cache and fix forward string search

### DIFF
--- a/search.go
+++ b/search.go
@@ -4,9 +4,18 @@ import "strings"
 
 func (v *View) SearchForward(pattern string) (bool, int, int) {
 	rx, ry, _ := v.realPosition(v.cx, v.cy)
+	if len(pattern) == 0 {
+		pattern = v.searchString
+	}
 	if len(pattern) > 0 {
-		if ind := strings.Index(string(v.lines[ry][rx:]), pattern); ind > -1 {
-			return true, ind + rx, ry
+		v.searchString = pattern
+
+		// Start searching one character beyond where we are
+		// or we won't be able to continue to the next match
+		if len(v.lines[ry]) > rx+1 {
+			if ind := strings.Index(string(v.lines[ry][rx+1:]), pattern); ind > -1 {
+				return true, ind + rx, ry
+			}
 		}
 		for i := ry + 1; i < len(v.lines); i++ {
 			if ind := strings.Index(string(v.lines[i]), pattern); ind > -1 {

--- a/view.go
+++ b/view.go
@@ -113,6 +113,7 @@ type View struct {
 	lines          [][]rune
 	readOffset     int
 	readCache      string
+	searchString   string
 
 	Actions Context
 
@@ -182,6 +183,10 @@ func newView(name string, x0, y0, x1, y1 int) *View {
 		tainted: true,
 	}
 	return v
+}
+
+func (v *View) GetSearchString() string {
+	return v.searchString
 }
 
 // Size returns the number of visible columns and rows in the View.


### PR DESCRIPTION
Searching a string immediately after a match was found would immediately find the very same match and not advance to the next one. Also, the previously searched string wasn't cached for subsequent
invocations.
